### PR TITLE
Format DateRangePickerComponent dates in European format rather than American

### DIFF
--- a/website/src/components/DateRangePickerComponent.js
+++ b/website/src/components/DateRangePickerComponent.js
@@ -42,6 +42,7 @@ function DateRangePickerComponent({ onDateRangeChange, availableDates }) {
                 <div style={{ marginBottom: '1vh' }}>
                     <DatePicker
                         label="Start Date"
+                        format="DD/MM/YYYY"
                         value={startDate}
                         onChange={handleStartDateChange}
                         shouldDisableDate={shouldDisableDate}
@@ -51,6 +52,7 @@ function DateRangePickerComponent({ onDateRangeChange, availableDates }) {
                 <div>
                     <DatePicker
                         label="End Date"
+                        format="DD/MM/YYYY"
                         value={endDate}
                         onChange={handleEndDateChange}
                         shouldDisableDate={shouldDisableDate}


### PR DESCRIPTION
LocalizationProvider with dayjs otherwise needs dayjs locales to be loaded and picked to work, and there are too many European locales to do that without affecting bundle size.

Luxon though wouldn't require locale data, as uses the browser Intl api to format dates.